### PR TITLE
Fix last event snapshot retrieving and transformation.

### DIFF
--- a/src/Infrastructure/Laravel/Illuminate/Log/Event.php
+++ b/src/Infrastructure/Laravel/Illuminate/Log/Event.php
@@ -109,6 +109,8 @@ class Event implements \BoundedContext\Contracts\Sourced\Log\Event
             return null;
         }
 
-        return $this->snapshot_transformer->fromPopo($event);
+        $popo_snapshot = $this->json_serializer->deserialize($event->snapshot);
+
+        return $this->snapshot_transformer->fromPopo($popo_snapshot);
     }
 }


### PR DESCRIPTION
Using `snapshot` field instead of whole record for building event snapshot.